### PR TITLE
Loosen python reqs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "python-dotenv==1.0.0",
-    "requests==2.28.2",
-    "pytest==7.2.2",
-    "pytest-asyncio==0.21.0",
-    "aiohttp==3.8.4",
-    "aiofiles==23.2.1",
-    "fire==0.5.0"
+    "python-dotenv>=1.0.0",
+    "requests>=2.28.2",
+    "pytest>=7.2.2",
+    "pytest-asyncio>=0.21.0",
+    "aiohttp>=3.8.4",
+    "aiofiles>=23.2.1",
+    "fire>=0.5.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
Hi, for a lib, specifically pinned requirements make it pretty hard to integrate into a larger project with a myriad of other requirements - this specifies requirements just as a minimum; if there are specific max version requirements, salt to taste...